### PR TITLE
Don't hardcode where / points in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
           r1=$(grep -F "Location:" <<< "$http")
           http=$(curl -v http://localhost:3000/root 2>&1)
           grep -F "HTTP/1.1 308" <<< "$http"
-          r2=$(grep -F "Location:m" <<< "$http")
+          r2=$(grep -F "Location:" <<< "$http")
           test "$r1" -eq "$r2"
       - name: curl -v http://localhost:3000/about
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
           http=$(curl -v http://localhost:3000/root 2>&1)
           grep -F "HTTP/1.1 308" <<< "$http"
           r2=$(grep -F "Location:" <<< "$http")
-          test "$r1" -eq "$r2"
+          test "$r1" = "$r2"
       - name: curl -v http://localhost:3000/about
         run: |
           set -euxo pipefail

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,11 @@ jobs:
           set -euxo pipefail
           http=$(curl -v http://localhost:3000/ 2>&1)
           grep -F "HTTP/1.1 308" <<< "$http"
-          grep -F "Location: https://rust-for-rustaceans.com" <<< "$http"
+          r1=$(grep -F "Location:" <<< "$http")
+          http=$(curl -v http://localhost:3000/root 2>&1)
+          grep -F "HTTP/1.1 308" <<< "$http"
+          r2=$(grep -F "Location:m" <<< "$http")
+          test "$r1" -eq "$r2"
       - name: curl -v http://localhost:3000/about
         run: |
           set -euxo pipefail

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -33,11 +33,13 @@ async fn root() {
         .redirect(redirect::Policy::none())
         .build()
         .unwrap();
-    let r = c.get(&app).send().await.unwrap();
-    assert_eq!(r.status(), StatusCode::PERMANENT_REDIRECT);
+    let implicit_root = c.get(&app).send().await.unwrap();
+    assert_eq!(implicit_root.status(), StatusCode::PERMANENT_REDIRECT);
+    let explicit_root = c.get(format!("{app}/root")).send().await.unwrap();
+    assert_eq!(explicit_root.status(), StatusCode::PERMANENT_REDIRECT);
     assert_eq!(
-        r.headers().get(http::header::LOCATION).unwrap(),
-        "https://rust-for-rustaceans.com"
+        implicit_root.headers().get(http::header::LOCATION).unwrap(),
+        explicit_root.headers().get(http::header::LOCATION).unwrap(),
     );
 }
 


### PR DESCRIPTION
So that CI doesn't fail if someone changes `src/lib.rs` in a fork.