### PR TITLE
Allow TF Plan to run on 3rd party PRs

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,14 +1,13 @@
 name: terraform
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     paths:
       # Only plan if TF has changed, even though we may _apply_ regardless
       # to re-push Rust artifacts.
       - "infra/**.tf"
-      - ".github/workflows/terraform-plan.yml"
 
 jobs:
   plan:
@@ -20,18 +19,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: cargo install cargo-lambda
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-lambda@1
-
-      - name: Install zig for cargo-lambda
-        run: sudo snap install zig --classic --beta
-
-      - run: cargo lambda build --release --arm64
+      # we do not run the actual build, since a user could then inject a
+      # malicious build.rs to leak our GITHUB_TOKEN. Instead, we just touch a
+      # file in the right place that terraform plan will then use as "the
+      # lambda binary". This is fine since plan doesn't actually apply
+      # anything. See also
+      # https://github.com/jonhoo/onwards/pull/7#issuecomment-3046317254
+      - name: fake cargo lambda build
+        run: |
+          mkdir -p target/lambda/lambda
+          touch target/lambda/lambda/bootstrap
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
If this works, we should then be able to move the TF state to S3 such that it does not need to be checked into the repository, as per https://github.com/jonhoo/onwards/pull/7#issuecomment-3043457684