### PR TITLE
Measure invocation time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
           grep -F "Location: https://github.com/jonhoo/onwards" <<< "$http"
       - name: measure invocation time
         run: |
-          curl -w @- -o /dev/null -s http://localhost:3000/root <<'EOF
+          curl -w @- -o /dev/null -s http://localhost:3000/root <<'EOF'
               time_namelookup:  %{time_namelookup}\n
                  time_connect:  %{time_connect}\n
               time_appconnect:  %{time_appconnect}\n

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,3 +80,15 @@ jobs:
           http=$(curl -v http://localhost:3000/about 2>&1)
           grep -F "HTTP/1.1 308" <<< "$http"
           grep -F "Location: https://github.com/jonhoo/onwards" <<< "$http"
+      - name: measure invocation time
+        run: |
+          curl -w @- -o /dev/null -s http://localhost:3000/root <<'EOF
+              time_namelookup:  %{time_namelookup}\n
+                 time_connect:  %{time_connect}\n
+              time_appconnect:  %{time_appconnect}\n
+             time_pretransfer:  %{time_pretransfer}\n
+                time_redirect:  %{time_redirect}\n
+           time_starttransfer:  %{time_starttransfer}\n
+                              ----------\n
+                   time_total:  %{time_total}\n
+          EOF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
           grep -F "Location: https://github.com/jonhoo/onwards" <<< "$http"
       - name: measure invocation time
         run: |
-          curl -w @- -o /dev/null -s http://localhost:3000/root <<'EOF'
+          for i in $(seq 1 3); do curl -w @- -o /dev/null -s http://localhost:3000/root <<'EOF'
               time_namelookup:  %{time_namelookup}\n
                  time_connect:  %{time_connect}\n
               time_appconnect:  %{time_appconnect}\n
@@ -92,3 +92,4 @@ jobs:
                               ----------\n
                    time_total:  %{time_total}\n
           EOF
+          done


### PR DESCRIPTION
According to
https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/using-sam-cli-local-start-api.html, each invocation should spawn a fresh lambda, meaning this should include everything associated with starting the lambda binary as well (and thus should show an improvement for #12).